### PR TITLE
Specify ubuntu CI version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We use python 3.10 because it is default on Ubuntu 22 LTS But pip on ubuntu-latest cannot find a hash for exceptiongroup. See this PR opensafely-core/pipeline#168.

We will explore updating the python version at a later date.